### PR TITLE
Bugfix/docker build memory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ WORKDIR /agentsim-dev/agentsim
 RUN git submodule update --init --recursive
 
 # build agentsim project
+# ENABLE_UNITY_BUILD is for AWS CPP SDK.  Turn it on for faster build but requires more memory to build.
 RUN cd ../build && \
 	cmake ../agentsim -DBUILD_ONLY="s3;awstransfer;transfer" -DENABLE_UNITY_BUILD=OFF -DCMAKE_BUILD_TYPE=Release -DAUTORUN_UNIT_TESTS=OFF && \
 	make && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN git submodule update --init --recursive
 
 # build agentsim project
 RUN cd ../build && \
-	cmake ../agentsim -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release -DAUTORUN_UNIT_TESTS=OFF && \
+	cmake ../agentsim -DBUILD_ONLY="s3;awstransfer;transfer" -DENABLE_UNITY_BUILD=OFF -DCMAKE_BUILD_TYPE=Release -DAUTORUN_UNIT_TESTS=OFF && \
 	make && \
   	openssl dhparam -out /dh.pem 2048 && \
 	find /agentsim-dev/build | grep -i so$ | xargs -i cp {} /agentsim-dev/lib/

--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,7 @@ done
 image_name=$(get_image_name)
 image_tag=$(next_image_tag)
 image_name_tag="${image_name}:${image_tag}"
-/usr/bin/docker build --pull -m 4g -t ${image_name_tag} .
+/usr/bin/docker build --pull -t ${image_name_tag} .
 if [[ $push_to_remote == 1 ]] ; then
     stage_registry=$(get_stage_registry)
     /usr/bin/docker tag ${image_name_tag} ${stage_registry}/${image_name_tag}

--- a/build.sh
+++ b/build.sh
@@ -103,7 +103,7 @@ done
 image_name=$(get_image_name)
 image_tag=$(next_image_tag)
 image_name_tag="${image_name}:${image_tag}"
-/usr/bin/docker build --pull -t ${image_name_tag} .
+/usr/bin/docker build --pull -m 4g -t ${image_name_tag} .
 if [[ $push_to_remote == 1 ]] ; then
     stage_registry=$(get_stage_registry)
     /usr/bin/docker tag ${image_name_tag} ${stage_registry}/${image_name_tag}

--- a/local_build.sh
+++ b/local_build.sh
@@ -4,6 +4,7 @@ echo $sourceDir
 
 if [[ -n "$sourceDir" ]]; then
   export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+  # ENABLE_UNITY_BUILD is for AWS CPP SDK.  Turn it on for faster build but requires more memory to build.
   cmake $sourceDir -DBUILD_ONLY="s3;awstransfer;transfer" -DENABLE_UNITY_BUILD=OFF -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DAUTORUN_UNIT_TESTS=OFF
   make
   mkcert -install

--- a/local_build.sh
+++ b/local_build.sh
@@ -4,7 +4,7 @@ echo $sourceDir
 
 if [[ -n "$sourceDir" ]]; then
   export PATH="/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  cmake $sourceDir -DBUILD_ONLY="s3;awstransfer;transfer" -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DAUTORUN_UNIT_TESTS=OFF
+  cmake $sourceDir -DBUILD_ONLY="s3;awstransfer;transfer" -DENABLE_UNITY_BUILD=OFF -DCMAKE_BUILD_TYPE=Release -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DAUTORUN_UNIT_TESTS=OFF
   make
   mkcert -install
   mkcert localhost


### PR DESCRIPTION
Jenkins builds were failing, apparently due to a single file in the AWS CPP SDK that we compile in.  I found this issue which had the same error.
 https://github.com/awslabs/aws-lambda-cpp/issues/14 
Here is my jenkins log showing the same error happening:  https://jenkins.corp.alleninstitute.org/job/docker-images/job/agentsim/job/main/8/execution/node/22/log/ 

It appears that the build was basically causing memory issues with the compiler on our Jenkins machines.  It's not trivial to add memory capacity on Jenkins.
I discovered that the AWS SDK has a build flag to avoid this situation which slows the build down but requires less memory.
Switching the build flag seems to make the build happy again.