### PR TITLE
use "1ns" as base unit for v1 trajectories

### DIFF
--- a/inc/test/network/dummy_trajinfo_data.h
+++ b/inc/test/network/dummy_trajinfo_data.h
@@ -55,12 +55,12 @@ namespace simularium {
     "totalSteps": 100,
     "timeStepSize": 1,
     "timeUnits": {
-      "magnitude": 1e-9,
-      "name": "nano"
+      "magnitude": 1,
+      "name": "ns"
     },
     "spatialUnits": {
-      "magnitude": 1e-9,
-      "name": "nano"
+      "magnitude": 1,
+      "name": "ns"
     },
     "typeMapping": {
       "0" : {
@@ -103,12 +103,12 @@ namespace simularium {
     "totalSteps": 100,
     "timeStepSize": 1,
     "timeUnits": {
-      "magnitude": 1e-9,
-      "name": "nano"
+      "magnitude": 1,
+      "name": "ns"
     },
     "spatialUnits": {
-      "magnitude": 1e-9,
-      "name": "nano"
+      "magnitude": 1,
+      "name": "ns"
     },
     "typeMapping": {
       "0" : {

--- a/src/main/parse_traj_info.cpp
+++ b/src/main/parse_traj_info.cpp
@@ -122,11 +122,11 @@ namespace simularium {
         parse_v1_box_size(tfp, fprops);
         parse_metadata_v1(tfp, fprops);
 
-        tfp.spatialUnits.magnitude = 1e-9;
-        tfp.spatialUnits.name = "nano";
+        tfp.spatialUnits.magnitude = 1;
+        tfp.spatialUnits.name = "ns";
 
-        tfp.timeUnits.magnitude = 1e-9;
-        tfp.timeUnits.name = "nano";
+        tfp.timeUnits.magnitude = 1;
+        tfp.timeUnits.name = "ns";
 
         parse_optional_v1_camera_default(tfp, fprops);
 


### PR DESCRIPTION
changing "nano" to "ns" and basic time unit multiplier, for v1 trajectory parsing
